### PR TITLE
Handle null user identity lookup in cleanse.php

### DIFF
--- a/maintenance/cleanse.php
+++ b/maintenance/cleanse.php
@@ -73,7 +73,7 @@ class Cleanse extends Maintenance {
 				$this->userIdentityLookup->getUserIdentityByName(
 					$this->getOption( 'remove-user' )
 				);
-			if ( !$target->isRegistered() ) {
+			if ( $target === null || !$target->isRegistered() ) {
 				$this->fatalError( 'Given user account does not exist' );
 			}
 			$this->removeUser( $target, $admin );


### PR DESCRIPTION
Updated the user identity retrieval logic to check for null values before accessing `isRegistered()`. This prevents potential fatal errors when an invalid or non-existent username is passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for user removal operations to properly handle non-existent user accounts with a clearer error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->