### PR TITLE
Improve user filtering in cleanse.php with preview page validation

### DIFF
--- a/maintenance/cleanse.php
+++ b/maintenance/cleanse.php
@@ -241,6 +241,14 @@ class Cleanse extends Maintenance {
 			}
 		}
 
+		if ( $smallestSeenLogId === null ) {
+			if ( $candidates !== [] ) {
+				$smallestSeenLogId = min( array_column( $candidates, 'log_id' ) );
+			} elseif ( $this->beforeLogId !== null ) {
+				$smallestSeenLogId = $this->beforeLogId;
+			}
+		}
+
 		if ( $smallestSeenLogId !== null ) {
 			echo "Next run cursor: --before-log-id $smallestSeenLogId\n";
 		}

--- a/maintenance/cleanse.php
+++ b/maintenance/cleanse.php
@@ -188,20 +188,27 @@ class Cleanse extends Maintenance {
 
 	private function cleanseSpam( UserIdentity $admin ): void {
 		$candidates = $this->getNewUsersFromLog();
-		$count = count( $candidates );
-		echo "Found $count new users to review\n";
-
-		$smallestSeenLogId = null;
+		$reviewCandidates = [];
 		foreach ( $candidates as $candidate ) {
-			$user = $candidate['user'];
-			$previewPages = $this->getRecentPagesForUser( $user, $this->pagesPerUser );
-			$userName = $user->getName();
-			$email = $user->getEmail();
-			$logId = $candidate['log_id'];
-
+			$previewPages = $this->getRecentPagesForUser( $candidate['user'], $this->pagesPerUser );
 			if ( $previewPages === [] ) {
 				continue;
 			}
+
+			$candidate['preview_pages'] = $previewPages;
+			$reviewCandidates[] = $candidate;
+		}
+
+		$count = count( $reviewCandidates );
+		echo "Found $count new users to review\n";
+
+		$smallestSeenLogId = null;
+		foreach ( $reviewCandidates as $candidate ) {
+			$user = $candidate['user'];
+			$previewPages = $candidate['preview_pages'];
+			$userName = $user->getName();
+			$email = $user->getEmail();
+			$logId = $candidate['log_id'];
 
 			$smallestSeenLogId = $smallestSeenLogId === null ? $logId : min( $smallestSeenLogId, $logId );
 


### PR DESCRIPTION
Refactored the spam-cleansing logic to filter before showing number of users to review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved spam review tooling: pre-fetches and caches candidate preview data to avoid redundant work.
  * Skips candidates with no preview content to speed processing.
  * Better computation of the next-run cursor to ensure consistent progress between runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nikerabbit/mediawiki-extensions-SapphireSpamCleanse/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->